### PR TITLE
Update dependenices and enable outdated for all CI

### DIFF
--- a/.github/workflows/validation-rust.yaml
+++ b/.github/workflows/validation-rust.yaml
@@ -79,7 +79,6 @@ jobs:
   outdated:
     name: Outdated
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,9 +592,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "svg"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d815ad337e8449d2374d4248448645edfe74e699343dd5719139d93fa87112"
+checksum = "0d703a3635418d4e4d0e410009ddbfb65047ef9468b1d29afd3b057a5bc4c217"
 
 [[package]]
 name = "syn"

--- a/altium-macros/Cargo.toml
+++ b/altium-macros/Cargo.toml
@@ -11,10 +11,10 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.6.0"
-proc-macro2 = "1.0.67"
+proc-macro2 = "1.0.69"
 quote = "1.0.33"
-regex = "1.9.5"
-syn = "2.0.37"
+regex = "1.10.2"
+syn = "2.0.38"
 # syn = { version = "2.0.22", features = ["extra-traits"] }
 
 [package.metadata.release]

--- a/altium/Cargo.toml
+++ b/altium/Cargo.toml
@@ -8,24 +8,24 @@ description = "A library for processing Altium file types"
 
 [dependencies]
 altium-macros = { path = "../altium-macros", version = "0.1.0" }
-base64 = "0.21.4"
+base64 = "0.21.5"
 # Use custom rev so we get debug outputs
 cfb = { git = "https://github.com/mdsteele/rust-cfb.git", rev = "5c5279d6" }
 # cfb = "0.8.1"
-flate2 = "1.0.27"
+flate2 = "1.0.28"
 # image = "0.24.6"
 image = { version = "0.24.7", default-features = false, features = ["png", "bmp", "jpeg"] }
 lazy_static = "1.4.0"
 log = "0.4.20"
 num_enum = "0.7.0"
 quick-xml = "0.30.0"
-regex = "1.9.5"
+regex = "1.10.2"
 rust-ini = "0.19.0"
-serde = "1.0.188"
+serde = "1.0.189"
 serde-xml-rs = "0.6.0"
-svg = "0.13.1"
-uuid = { version = "1.4.1", features = ["v1", "v4", "fast-rng"]}
-xml-rs = "0.8.18"
+svg = "0.14.0"
+uuid = { version = "1.5.0", features = ["v1", "v4", "fast-rng"]}
+xml-rs = "0.8.19"
 
 [dev-dependencies]
 env_logger = "0.10.0"


### PR DESCRIPTION
Update dependencies to fix warnings for cargo-outdated. Enable cargo-outdated for all CI (including PRs) so we get this before merge.