### PR TITLE
ci: Clean up the workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,8 +31,9 @@ jobs:
       matrix:
         include:
         - os: ubuntu-24.04
-        - os: macos-15
-        - os: windows-2025
+        # Disabled to keep CI lighter weight
+        # - os: macos-15
+        # - os: windows-2025
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,59 +1,45 @@
----
-
-# Main "useful" actions config file
-# Cache config comes from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
+name: CI
 
 on:
-  push:
-    branches:
-    - main
+  push: { branches: [main] }
   pull_request:
 
-name: Rust Validation
-
 env:
-  RUSTDOCFLAGS: -D warnings
-  RUSTFLAGS: -D warnings
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: -Dwarnings
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: full
 
 jobs:
   clippy:
-    name: "Clippy (cargo clippy)"
-    runs-on: ubuntu-latest
+    name: Clippy
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup default nightly
+      - uses: actions/checkout@v6
+      - run: rustup update nightly --no-self-update && rustup default nightly
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
-      - run: cargo clippy --all-features --all-targets -- -D warnings
-      - run: cargo clippy --no-default-features --all-targets -- -D warnings
+      - run: cargo clippy --all-features --all-targets
 
   test:
+    name: Build and test
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:
         include:
-        - build: linux
-          os: ubuntu-latest
-          target: x86_64-unknown-linux-musl
-          extension: ''
-        - build: macos
-          os: macos-latest
-          target: x86_64-apple-darwin
-          extension: ''
-        - build: windows-msvc
-          os: windows-latest
-          target: x86_64-pc-windows-msvc
-    name: "Test on ${{ matrix.os }} (cargo test)"
+        - os: ubuntu-24.04
+        - os: macos-15
+        - os: windows-2025
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - run: rustup update stable --no-self-update && rustup default stable
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
@@ -63,9 +49,10 @@ jobs:
       - run: cargo test --doc
 
   msrv:
+    timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: |
           msrv="$(
             cargo metadata --no-deps --format-version 1 |
@@ -75,22 +62,24 @@ jobs:
       - run: cargo check -p altium
 
   fmt:
-    name: "Format (cargo fmt)"
-    runs-on: ubuntu-latest
+    name: Rustfmt
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup default nightly
+      - uses: actions/checkout@v6
+      - run: rustup update nightly --no-self-update && rustup default nightly
       - run: rustup component add rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
       - uses: actions/setup-python@v3
 
   doc:
-    name: "Docs (cargo doc)"
-    runs-on: ubuntu-latest
+    name: Docs
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup default nightly
+      - uses: actions/checkout@v6
+      - run: rustup update nightly --no-self-update && rustup default nightly
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev
       - run: cargo doc --no-deps

--- a/ecadg/src/main.rs
+++ b/ecadg/src/main.rs
@@ -21,7 +21,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     parse_args()?;
 
     let native_options = eframe::NativeOptions::default();
-    log::info!("ABC");
     eframe::run_native(
         "ecadg",
         native_options,


### PR DESCRIPTION
* Enable color logging
* Simplify job names
* Simplify the test matrix
* Set timeouts
* Be consistent with rustup updates